### PR TITLE
Update Defense

### DIFF
--- a/MahjongAI/AIControllerDef.cs
+++ b/MahjongAI/AIControllerDef.cs
@@ -22,14 +22,14 @@ namespace MahjongAI
             return (gameData.players.Any(p => defLevel(p) >= 4)
                     && (evalResult.Distance >= 3
                         || evalResult.Distance == 2 && (evalResult.E_PromotionCount[0] <= 8 || evalResult.E_Point < 8000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
-                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 5 || evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
-                        || (evalResult.Distance == 0 && evalResult.E_Point < 2000 || gameData.remainingTile / 4 <= evalResult.Distance * 2)
+                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 4 || evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
+                        || (evalResult.Distance == 0 && (evalResult.E_Point < 2000 || evalResult.E_PromotionCount[0] < 1) || gameData.remainingTile / 4 <= evalResult.Distance * 2)
                             && (discardTile == null || evalDef(discardTile).Risk > 15))
                 || gameData.players.Any(p => defLevel(p) >= 2)
                     && (evalResult.Distance >= 3
                         || evalResult.Distance == 2 && (evalResult.E_PromotionCount[0] <= 8 || evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
-                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 5 || evalResult.E_Point < 2000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
-                        || (evalResult.Distance == 0 && evalResult.E_Point < 1000 || evalResult.Distance > 0 && gameData.remainingTile / 4 <= evalResult.Distance * 2)
+                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 4 || evalResult.E_Point < 2000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
+                        || (evalResult.Distance == 0 && (evalResult.E_Point < 1000 || evalResult.E_PromotionCount[0] < 1) || evalResult.Distance > 0 && gameData.remainingTile / 4 <= evalResult.Distance * 2)
                             && (discardTile == null || evalDef(discardTile).Risk > 15))
                 || gameData.players.Any(p => defLevel(p) >= 1)
                     && evalResult.Distance >= 2)

--- a/MahjongAI/AIControllerDef.cs
+++ b/MahjongAI/AIControllerDef.cs
@@ -20,13 +20,15 @@ namespace MahjongAI
             if (strategy.DefenceLevel == Strategy.DefenceLevelType.DefendReachedPlayers && gameData.players.All(p => !p.reached)) return false;
 
             return (gameData.players.Any(p => defLevel(p) >= 4)
-                    && (evalResult.Distance >= 2 && (evalResult.E_Point < 8000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
-                        || evalResult.Distance == 1 && (evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
+                    && (evalResult.Distance >= 3
+                        || evalResult.Distance == 2 && (evalResult.E_PromotionCount[0] <= 8 || evalResult.E_Point < 8000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
+                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 5 || evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
                         || (evalResult.Distance == 0 && evalResult.E_Point < 2000 || gameData.remainingTile / 4 <= evalResult.Distance * 2)
                             && (discardTile == null || evalDef(discardTile).Risk > 15))
                 || gameData.players.Any(p => defLevel(p) >= 2)
-                    && (evalResult.Distance >= 2 && (evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
-                        || evalResult.Distance == 1 && (evalResult.E_Point < 2000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
+                    && (evalResult.Distance >= 3
+                        || evalResult.Distance == 2 && (evalResult.E_PromotionCount[0] <= 8 || evalResult.E_Point < 4000 || evalResult.E_PromotionCount[0] <= 15 && evalResult.E_Point < 12000)
+                        || evalResult.Distance == 1 && (evalResult.E_PromotionCount[0] <= 5 || evalResult.E_Point < 2000 || evalResult.E_PromotionCount[0] <= 9 && evalResult.E_Point < 8000)
                         || (evalResult.Distance == 0 && evalResult.E_Point < 1000 || evalResult.Distance > 0 && gameData.remainingTile / 4 <= evalResult.Distance * 2)
                             && (discardTile == null || evalDef(discardTile).Risk > 15))
                 || gameData.players.Any(p => defLevel(p) >= 1)
@@ -150,14 +152,18 @@ namespace MahjongAI
                 res.Risk = evalDefMid(tile, forPlayer);
             }
 
-            var tmp = forPlayer.graveyard.Where(t => t.Type != "z" && t.Number != 1 && t.Number != 9).Take(2).ToList();
+            var tmp = forPlayer.graveyard.Where(t => t.Type != "z" && t.Number != 1 && t.Number != 9).Take(3).ToList();
             if (tmp.Count >= 1 && isOutsideOf(tile, tmp[0]))
             {
                 res.Risk /= 4;
             }
-            if (tmp.Count >= 2 && isOutsideOf(tile, tmp[1]))
+            else if (tmp.Count >= 2 && isOutsideOf(tile, tmp[1]))
             {
                 res.Risk /= 2;
+            }
+            else if (tmp.Count >= 3 && isOutsideOf(tile, tmp[2]))
+            {
+                res.Risk -= 1;
             }
 
             if (doraValue(tile) > 0)


### PR DESCRIPTION
改进了防守方面的以下个点：
1、自己三向听以上必然弃和。
2、进张特别少时无论牌多大也弃和。
3、空听时也应当弃和。
4、外侧不重复计算，因为往往第二张是摸切的不提供额外信息，或者5566连对牌拆掉了一副。
5、第三张外侧也考虑进来，-1只是为了和其他牌稍微有点区分。