### PR TITLE
Fix calculate actual points on Tenhou

### DIFF
--- a/MahjongAI/TenhouClient.cs
+++ b/MahjongAI/TenhouClient.cs
@@ -258,8 +258,10 @@ namespace MahjongAI
                     int[] pointDeltas = new int[4];
                     for (var i = 0; i < 4; i++)
                     {
-                        gameData.players[i].point = scFields[i * 2] * 100;
-                        pointDeltas[i] = scFields[i * 2 + 1] * 100;
+                        int currentPoints = scFields[i * 2] * 100;
+                        int currentDelta = scFields[i * 2 + 1] * 100;
+                        gameData.players[i].point = currentPoints + currentDelta;
+                        pointDeltas[i] = currentDelta;
                     }
 
                     if (pointDeltas.Any(p => p >= 32000))


### PR DESCRIPTION
On Tenhou we can't see actual points after delta on agari trace msg. 

Screen with wrong actual points on Tenhou:
![diff_tenhou_error](https://user-images.githubusercontent.com/343531/139596852-2e4f4a5a-f6de-471f-8469-c32da11e9ab3.png)

For example same trace msg on Majsoul :
![diff_ms](https://user-images.githubusercontent.com/343531/139596820-9124a9e1-8cfb-494b-9522-f9bd8f00c402.png)
 
After fix in this PR we can see actual points on Tenhou:
![diff_fix_tenhou](https://user-images.githubusercontent.com/343531/139596889-ebde080a-1564-476f-9f80-c97132c9ec9f.png)

