### PR TITLE
Support auto load protocol version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:5.16.0
+FROM mono:6.12.0
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
     && apt-get install -y nodejs
 COPY . /usr/src/app

--- a/MahjongAI/Constants.cs
+++ b/MahjongAI/Constants.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MahjongAI.Models;
 
 namespace MahjongAI
 {
     static class Constants
     {
+        public const string CN_GAME_SERVER_HOST = "https://game.maj-soul.com/1";
+
         public static readonly IReadOnlyDictionary<MajsoulRegion, string> MAJSOUL_API_URL_PRIFIX = new Dictionary<MajsoulRegion, string>()
         {
             { MajsoulRegion.CN_INTERNATIONAL_1, "https://lb-hw.maj-soul.com/api/v0" },

--- a/MahjongAI/MahjongAI.csproj
+++ b/MahjongAI/MahjongAI.csproj
@@ -38,6 +38,9 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MahjongAI/packages.config
+++ b/MahjongAI/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
proposal:  we can extract current protocol version from REST entry point https://game.maj-soul.com/1/version.json  (CN server) at startup and replace hardcoded version constants in code by extracted version string.
Also for fix downloading node 11.x version we need upgrade docker mono image.